### PR TITLE
Return HTTP status 405 from update_ingestion_attempt

### DIFF
--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -88,20 +88,19 @@ def profile(request):
 
 @api_view(["PUT"])
 def update_ingestion_attempt(request):
-    if request.method == 'PUT':
-        auth = request.headers.get("Authorization")
-        try:
-            instance = IngestionAttempt.objects.get(uuid=request.PUT['uuid'])
-            if (not check_authorized(auth, instance.site, instance.project)):
-                return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
-            form = IngestionAttemptForm(request.PUT, instance=instance)
-        except IngestionAttempt.DoesNotExist:
-            # IngestionAttempt doesn't exists, so we create a new one
-            form = IngestionAttemptForm(request.PUT)
-        if form.is_valid():
-            if (not check_authorized(auth, form.instance.site, form.instance.project)):
-                return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
-            ingestion = form.save()
-            return HttpResponse(ingestion.uuid, status=status.HTTP_201_CREATED)
-        else:
-            return HttpResponse(form.errors, status=status.HTTP_400_BAD_REQUEST)
+    auth = request.headers.get("Authorization")
+    try:
+        instance = IngestionAttempt.objects.get(uuid=request.PUT['uuid'])
+        if (not check_authorized(auth, instance.site, instance.project)):
+            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        form = IngestionAttemptForm(request.PUT, instance=instance)
+    except IngestionAttempt.DoesNotExist:
+        # IngestionAttempt doesn't exists, so we create a new one
+        form = IngestionAttemptForm(request.PUT)
+    if form.is_valid():
+        if (not check_authorized(auth, form.instance.site, form.instance.project)):
+            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        ingestion = form.save()
+        return HttpResponse(ingestion.uuid, status=status.HTTP_201_CREATED)
+    else:
+        return HttpResponse(form.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
~Returns 405 from `update_ingestion_attempt` if the request method is not `PUT`. This prevents Django errors in the logs and lets the user know what methods are allowed (currently just `PUT`).~

Use the `django-rest-framework` `@api_view` decorator on `update_ingestion_attempt` to only allow `PUT` requests. Ultimately returns HTTP status 405 is you make a non-`PUT` request.