### PR TITLE
Remove links section from docker-compose.yml

### DIFF
--- a/.github/workflows/ci-docker-compose.yml
+++ b/.github/workflows/ci-docker-compose.yml
@@ -1,0 +1,13 @@
+name: ci-docker-compose
+
+on: [pull_request]
+
+jobs:
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+      - name: Run docker compose
+        run: |
+          docker compose

--- a/.github/workflows/ci-docker-compose.yml
+++ b/.github/workflows/ci-docker-compose.yml
@@ -6,8 +6,10 @@ jobs:
   compose:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
-      - name: Run docker compose
+      - name: Run and tear down docker compose
         run: |
-          docker compose up
+          docker compose up -d
+          docker compose down

--- a/.github/workflows/ci-docker-compose.yml
+++ b/.github/workflows/ci-docker-compose.yml
@@ -10,4 +10,4 @@ jobs:
         uses: docker/setup-compose-action@v1
       - name: Run docker compose
         run: |
-          docker compose
+          docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ services:
     volumes:
       - ./agate:/agate
     working_dir: /agate
-    links:
-      - rabbitmq_service
-      - db_service
-      - phonyx_service
     depends_on:
       db_service:
         condition: service_healthy


### PR DESCRIPTION
The `links` section isn't needed to setup communication between services in newer versions of `docker-compose` (and it doesn't work with `podman`). 

[The docker-compose docs](https://docs.docker.com/reference/compose-file/services/#links) could be a bit clearer about this, but I think the crucial part is the following sentences

> Links are not required to enable services to communicate. When no specific network configuration is set, any service is able to reach any other service at that service’s name on the default network. 