### PR TITLE
CI Accessibility Testing

### DIFF
--- a/.github/workflows/ci-pa11y.yml
+++ b/.github/workflows/ci-pa11y.yml
@@ -27,6 +27,7 @@ jobs:
         pip install -r requirements-test.txt
     - name: Run Pa11y-CI Tests
       env:
+        # Path to chrome on GitHub action runners
         PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
       run: |
         cd agate

--- a/.github/workflows/ci-pa11y.yml
+++ b/.github/workflows/ci-pa11y.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-test.txt
-    - name: Run Tests
+    - name: Run Pa11y-CI Tests
       run: |
         cd agate
         mv core/local_settings.test.py core/local_settings.py

--- a/.github/workflows/ci-pa11y.yml
+++ b/.github/workflows/ci-pa11y.yml
@@ -26,6 +26,8 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
     - name: Run Pa11y-CI Tests
+      env:
+        PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
       run: |
         cd agate
         mv core/local_settings.test.py core/local_settings.py


### PR DESCRIPTION
It seems like some recent dependency change (I suspect [Pa11y-CI](https://www.npmjs.com/package/pa11y-ci), which just had a major-version bump) has caused tests to start to fail (see https://github.com/CLIMB-TRE/agate/actions/runs/16593096420/job/46933531202). 

This adds the `PUPPETEER_EXECUTABLE_PATH` and it seems to work.