### PR TITLE
Fix `update_ingestion_attempt`

### DIFF
--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -2,6 +2,7 @@ from django.http import JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 from .models import IngestionAttempt
 from .forms import IngestionAttemptForm
 import requests
@@ -81,19 +82,26 @@ def profile(request):
 
 @api_view(["PUT"])
 def update_ingestion_attempt(request):
+    """Creates or replaces the target resource."""
     auth = request.headers.get("Authorization")
+    # If we are updating an existing record, then we should return
+    # status 200 (or possibly 204?), but if we are creating a new
+    # record then we should return 201. See:
+    # https://www.rfc-editor.org/rfc/rfc7231#section-4.3.4
+    success_status = status.HTTP_200_OK
     try:
-        instance = IngestionAttempt.objects.get(uuid=request.PUT['uuid'])
-        if (not check_authorized(auth, instance.site, instance.project)):
+        instance = IngestionAttempt.objects.get(uuid=request.data.get('uuid'))
+        if not check_authorized(auth, instance.site, instance.project):
             return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
-        form = IngestionAttemptForm(request.PUT, instance=instance)
+        form = IngestionAttemptForm(request.data, instance=instance)
     except IngestionAttempt.DoesNotExist:
         # IngestionAttempt doesn't exists, so we create a new one
-        form = IngestionAttemptForm(request.PUT)
+        form = IngestionAttemptForm(request.data)
+        success_status = status.HTTP_201_CREATED
     if form.is_valid():
-        if (not check_authorized(auth, form.instance.site, form.instance.project)):
+        if not check_authorized(auth, form.instance.site, form.instance.project):
             return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
         ingestion = form.save()
-        return HttpResponse(ingestion.uuid, status=status.HTTP_201_CREATED)
+        return Response({"uuid": ingestion.uuid}, status=success_status)
     else:
         return HttpResponse(form.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse, HttpResponse
+from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.decorators import api_view
 from .models import IngestionAttempt
@@ -30,11 +31,9 @@ class IngestionAPIView(ListAPIView):
         return super().list(request, *args, **kwargs)
 
 
+@api_view(["GET"])
 def single_ingestion_attempt_response(request, uuid=""):
-    try:
-        obj = IngestionAttempt.objects.get(uuid=uuid)
-    except IngestionAttempt.DoesNotExist:
-        return HttpResponse('Not found', status=status.HTTP_404_NOT_FOUND)
+    obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
     if not check_authorized(auth, obj.site, obj.project):
@@ -43,11 +42,9 @@ def single_ingestion_attempt_response(request, uuid=""):
     return JsonResponse(serializer.data, safe=False)
 
 
+@api_view(["GET"])
 def archive_ingestion_attempt(request, uuid=""):
-    try:
-        obj = IngestionAttempt.objects.get(uuid=uuid)
-    except IngestionAttempt.DoesNotExist:
-        return HttpResponse('Not found', status=status.HTTP_404_NOT_FOUND)
+    obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
     if not check_authorized(auth, obj.site, obj.project):
@@ -57,12 +54,9 @@ def archive_ingestion_attempt(request, uuid=""):
     return HttpResponse(status=status.HTTP_200_OK)
 
 
+@api_view(["GET"])
 def delete_ingestion_attempt(request, uuid=""):
-
-    try:
-        obj = IngestionAttempt.objects.get(uuid=uuid)
-    except IngestionAttempt.DoesNotExist:
-        return HttpResponse('Not found', status=status.HTTP_404_NOT_FOUND)
+    obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
     if not check_authorized(auth, obj.site, obj.project):


### PR DESCRIPTION
As is the `update_ingestion_attempt` view doesn't work. This fixes that. I'm not really sure what we'd want to use this method for, but at the moment it is quite handy for manipulating the data once it is in the database for testing.

Note that #11 is included in this PR so that needs to be merged first.