### PR TITLE
Use DRF to handle forbidden requests

### DIFF
--- a/agate/agate/authorisation.py
+++ b/agate/agate/authorisation.py
@@ -12,6 +12,9 @@ def check_project_authorized(auth, project):
     """
     Check if the user is allowed to view this project.
 
+    Raises a `PermissionDenied` exception if not authorised to view
+    project, otherwise returns None.
+
     Returns True if a provided authorization token is valid to view a project,
     otherwise raises a `PermissionDenied` exception.
 
@@ -22,8 +25,9 @@ def check_project_authorized(auth, project):
     projects = _get_item(auth).projects_output
     for a in json.loads(projects)["data"]:
         if a["project"] == project:
-            return True
-    raise PermissionDenied("Not authorised to view this project")
+            break
+    else:
+        raise PermissionDenied("Not authorised to view this project")
 
 
 def find_site(auth):

--- a/agate/agate/tests/test_api_endpoints.py
+++ b/agate/agate/tests/test_api_endpoints.py
@@ -28,6 +28,22 @@ class IngestionAttemptAPITests(APITestCase):
             is_test_attempt=False,
         )
 
+        IngestionAttempt.objects.create(
+            uuid="forbidden_entry",
+            is_published=True,
+            project="forbidden_project",
+            site="here",
+            is_test_attempt=False,
+        )
+
+        IngestionAttempt.objects.create(
+            uuid="forbidden_site",
+            is_published=True,
+            project="project",
+            site="forbidden_site",
+            is_test_attempt=False,
+        )
+
         TokenCache.objects.create(
             projects_output='{"data": [{"project":"project"}]}',
             site_output="here",
@@ -135,3 +151,12 @@ class IngestionAttemptAPITests(APITestCase):
         """Test that putting bad data returns status code 400."""
         response = self.client.put(reverse("agate:update"), {"bad": "data"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_single_ingestion_attempt_forbidden(self):
+        response = self.client.get(reverse("agate:single", args=["forbidden_entry"]))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_single_ingestion_attempt_forbidden_site(self):
+        response = self.client.get(reverse("agate:single", args=["forbidden_site"]))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+

--- a/agate/agate/tests/test_api_endpoints.py
+++ b/agate/agate/tests/test_api_endpoints.py
@@ -159,4 +159,3 @@ class IngestionAttemptAPITests(APITestCase):
     def test_get_single_ingestion_attempt_forbidden_site(self):
         response = self.client.get(reverse("agate:single", args=["forbidden_site"]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-

--- a/agate/agate/tests/test_api_endpoints.py
+++ b/agate/agate/tests/test_api_endpoints.py
@@ -56,7 +56,7 @@ class IngestionAttemptAPITests(APITestCase):
     def test_unauthorized_access(self):
         # Test if the API correctly denies unauthorized access
         response = self.client.get(reverse("agate:ingestion"))
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_ingestion_attempts(self):
         # Test if GET returns the list of ingestion attempts

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -27,8 +27,7 @@ class IngestionAPIView(ListAPIView):
     def list(self, request, *args, **kwargs):
         auth = request.headers.get("Authorization")
         project_name = request.query_params.get("project", None)
-        if (project_name is None) or (not check_project_authorized(auth, project_name)):
-            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        check_project_authorized(auth, project_name)
         return super().list(request, *args, **kwargs)
 
 

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -88,16 +88,14 @@ def update_ingestion_attempt(request):
     success_status = status.HTTP_200_OK
     try:
         instance = IngestionAttempt.objects.get(uuid=request.data.get('uuid'))
-        if not check_authorized(auth, instance.site, instance.project):
-            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        check_authorized(auth, instance.site, instance.project)
         form = IngestionAttemptForm(request.data, instance=instance)
     except IngestionAttempt.DoesNotExist:
         # IngestionAttempt doesn't exists, so we create a new one
         form = IngestionAttemptForm(request.data)
         success_status = status.HTTP_201_CREATED
     if form.is_valid():
-        if not check_authorized(auth, form.instance.site, form.instance.project):
-            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        check_authorized(auth, form.instance.site, form.instance.project)
         ingestion = form.save()
         return Response({"uuid": ingestion.uuid}, status=success_status)
     else:

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -37,8 +37,7 @@ def single_ingestion_attempt_response(request, uuid=""):
     obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
-    if not check_authorized(auth, obj.site, obj.project):
-        return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+    check_authorized(auth, obj.site, obj.project)
     serializer = IngestionSerializer(obj)
     return JsonResponse(serializer.data, safe=False)
 
@@ -48,8 +47,7 @@ def archive_ingestion_attempt(request, uuid=""):
     obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
-    if not check_authorized(auth, obj.site, obj.project):
-        return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+    check_authorized(auth, obj.site, obj.project)
     obj.archived = True
     obj.save()
     return HttpResponse(status=status.HTTP_200_OK)
@@ -60,8 +58,7 @@ def delete_ingestion_attempt(request, uuid=""):
     obj = get_object_or_404(IngestionAttempt, uuid=uuid)
 
     auth = request.headers.get("Authorization")
-    if not check_authorized(auth, obj.site, obj.project):
-        return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+    check_authorized(auth, obj.site, obj.project)
     obj.delete()
     return HttpResponse(status=status.HTTP_200_OK)
 


### PR DESCRIPTION
I'm by no means sure, but I think that we want to be returning status 403 (Forbidden) when we have a valid token but don't have permission to view a project/site rather than 401 (Unauthorised). It is probably splitting hairs a bit.

This just simplifies the views a bit by raising an exception inside the authorisation functions, which gets propagated by DRF back to the response object.

Somewhere there should perhaps be another check for whether a token has been passed at all, and if not, then 401 can be returned. 

~Setting as draft for now as I'd like to make the changes to the `update_ingestion_attempt` view too once #14 has been merged.~