### PR TITLE
User Serializer instead of Form.

### DIFF
--- a/agate/agate/forms.py
+++ b/agate/agate/forms.py
@@ -1,9 +1,0 @@
-from django import forms
-
-from .models import IngestionAttempt
-
-
-class IngestionAttemptForm(forms.ModelForm):
-    class Meta:
-        model = IngestionAttempt
-        exclude = ["created_at", "updated_at"]

--- a/agate/agate/queue_reading/ingestion_updater.py
+++ b/agate/agate/queue_reading/ingestion_updater.py
@@ -1,6 +1,6 @@
 import logging
 from agate.models import IngestionAttempt
-from agate.forms import IngestionAttemptForm
+from agate.serializers import IngestionSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -46,14 +46,14 @@ class IngestionUpdater:
         """
         try:
             instance = IngestionAttempt.objects.get(uuid=uuid)
-            form = IngestionAttemptForm(data, instance=instance)
         except IngestionAttempt.DoesNotExist:
+            instance = None
             # IngestionAttempt doesn't exists, so we create a new one
-            form = IngestionAttemptForm(data)
-        if form.is_valid():
-            form.save()
+        serializer = IngestionSerializer(data=data, instance=instance)
+        if serializer.is_valid():
+            serializer.save()
         else:
-            logger.critical(f"invalid ingestion attempt message: {form.errors}")
+            logger.critical(f"invalid ingestion attempt message: {serializer.errors}")
 
     @classmethod
     def _status(cls, data: dict, stage: str):

--- a/agate/agate/serializers.py
+++ b/agate/agate/serializers.py
@@ -5,4 +5,5 @@ from .models import IngestionAttempt
 class IngestionSerializer(serializers.ModelSerializer):
     class Meta:
         model = IngestionAttempt
-        exclude = ''
+        fields = "__all__"
+        read_only_fields = ["created_at", "updated_at"]

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -4,7 +4,6 @@ from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from .models import IngestionAttempt
-from .forms import IngestionAttemptForm
 import requests
 from .authorisation import check_project_authorized, find_site, check_authorized
 from core.settings import ONYX_DOMAIN
@@ -84,24 +83,23 @@ def profile(request):
 def update_ingestion_attempt(request):
     """Creates or replaces the target resource."""
     auth = request.headers.get("Authorization")
+    try:
+        instance = IngestionAttempt.objects.get(uuid=request.data.get('uuid'))
+    except IngestionAttempt.DoesNotExist:
+        instance = None
+
     # If we are updating an existing record, then we should return
     # status 200 (or possibly 204?), but if we are creating a new
     # record then we should return 201. See:
     # https://www.rfc-editor.org/rfc/rfc7231#section-4.3.4
-    success_status = status.HTTP_200_OK
-    try:
-        instance = IngestionAttempt.objects.get(uuid=request.data.get('uuid'))
-        if not check_authorized(auth, instance.site, instance.project):
-            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
-        form = IngestionAttemptForm(request.data, instance=instance)
-    except IngestionAttempt.DoesNotExist:
-        # IngestionAttempt doesn't exists, so we create a new one
-        form = IngestionAttemptForm(request.data)
-        success_status = status.HTTP_201_CREATED
-    if form.is_valid():
-        if not check_authorized(auth, form.instance.site, form.instance.project):
-            return HttpResponse('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
-        ingestion = form.save()
-        return Response({"uuid": ingestion.uuid}, status=success_status)
+    if instance:
+        check_authorized(auth, instance.site, instance.project)
+        success_status = status.HTTP_200_OK
     else:
-        return HttpResponse(form.errors, status=status.HTTP_400_BAD_REQUEST)
+        success_status = status.HTTP_201_CREATED
+
+    serializer = IngestionSerializer(instance=instance, data=request.data)
+    serializer.is_valid(raise_exception=True)
+    check_authorized(auth, serializer.validated_data["site"], serializer.validated_data["project"])
+    ingestion = serializer.save()
+    return Response({"uuid": ingestion.uuid}, status=success_status)


### PR DESCRIPTION
[`ModelSerializers`](https://www.django-rest-framework.org/tutorial/1-serialization/#using-modelserializers) are django-rest-framework's equivalent of django forms. As far as I understand forms should be used for browser-based HTML and seralizers for JSON API-style things. Since we are the latter this deletes the `IngestionAttemptForm` class and leverages `IngestionSerializer` (which we already had) instead.

~Draft until #16 is merged~