### PR TITLE
Use `django.conf.settings`

### DIFF
--- a/agate/agate/authorisation.py
+++ b/agate/agate/authorisation.py
@@ -1,6 +1,6 @@
 import requests
 from .caching import TokenCache
-from core.settings import ONYX_DOMAIN
+from django.conf import settings
 from datetime import timedelta
 from django.utils import timezone
 import json
@@ -69,7 +69,7 @@ def _get_item(auth):
 
 def _populate_entry(auth):
 
-    route = f"{ONYX_DOMAIN}/projects"
+    route = f"{settings.ONYX_DOMAIN}/projects"
     headers = {"Authorization": auth}
     r = requests.get(route, headers=headers)
     if (not r.status_code == 200):
@@ -77,7 +77,7 @@ def _populate_entry(auth):
     else:
         projects = r.text
 
-    route = f"{ONYX_DOMAIN}/accounts/profile"
+    route = f"{settings.ONYX_DOMAIN}/accounts/profile"
     headers = {"Authorization": auth}
     r = requests.get(route, headers=headers)
     if (not r.status_code == 200):

--- a/agate/agate/scheduled_tasks.py
+++ b/agate/agate/scheduled_tasks.py
@@ -6,11 +6,11 @@ from datetime import timedelta
 from django.utils import timezone
 from .caching import TokenCache
 from .models import IngestionAttempt
-from core.settings import MESSAGE_RETRIEVAL
+from django.conf import settings
 
 _scheduler = BackgroundScheduler()
 
-_queue_reader = QueueReader(MESSAGE_RETRIEVAL)
+_queue_reader = QueueReader(settings.MESSAGE_RETRIEVAL)
 
 
 def queue_retrieve_task():

--- a/agate/agate/tests/test_authorisation.py
+++ b/agate/agate/tests/test_authorisation.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied
 
 from agate.authorisation import check_authorized, check_project_authorized, find_site
-from core.local_settings import ONYX_DOMAIN
+from django.conf import settings
 
 
 class AuthTestCase(TestCase):
@@ -15,13 +15,13 @@ class AuthTestCase(TestCase):
     @staticmethod
     def mock_onyx_request(url, *args, **kwargs):
 
-        if url == f"{ONYX_DOMAIN}/projects":
+        if url == f"{settings.ONYX_DOMAIN}/projects":
             response = Mock()
             response.status_code = 200
             response.text = json.dumps({"data": [{"project": "test_project"}]})
             return response
 
-        if url == f"{ONYX_DOMAIN}/accounts/profile":
+        if url == f"{settings.ONYX_DOMAIN}/accounts/profile":
             response = Mock()
             response.status_code = 200
             response.json.return_value = {"data": {"site": "test_site"}}

--- a/agate/agate/views.py
+++ b/agate/agate/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from .models import IngestionAttempt
 import requests
 from .authorisation import check_project_authorized, find_site, check_authorized
-from core.settings import ONYX_DOMAIN
+from django.conf import settings
 
 from .serializers import IngestionSerializer
 from .pagination import MyCursorPagination
@@ -62,14 +62,14 @@ def delete_ingestion_attempt(request, uuid=""):
 
 
 def projects(request):
-    route = f"{ONYX_DOMAIN}/projects"
+    route = f"{settings.ONYX_DOMAIN}/projects"
     headers = {"Authorization": request.headers.get("Authorization")}
     r = requests.get(route, headers=headers)
     return HttpResponse(r, status=r.status_code)
 
 
 def profile(request):
-    route = f"{ONYX_DOMAIN}/accounts/profile"
+    route = f"{settings.ONYX_DOMAIN}/accounts/profile"
     headers = {"Authorization": request.headers.get("Authorization")}
     r = requests.get(route, headers=headers)
     return HttpResponse(r, status=r.status_code)


### PR DESCRIPTION
Previously, settings were imported directly from `core/settings.py`. This isn't recommended because it shouldn't be assumed that that file exists. Instead settings should be accessed through `django.conf.settings` as recommended in [the docs](https://docs.djangoproject.com/en/6.0/topics/settings/#using-settings-in-python-code).

Note at some point a sort of imports would be good, but that is a separate issue!