### PR TITLE
Add github action to build and push image to ghcr

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version tag
+        id: vars
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./agate
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/$(basename ${{ github.repository }}):${{ steps.vars.outputs.TAG }}
+            ghcr.io/${{ github.repository_owner }}/$(basename ${{ github.repository }}):latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -37,7 +37,7 @@ jobs:
           context: ./agate
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/$(basename ${{ github.repository }}):${{ steps.vars.outputs.TAG }}
-            ghcr.io/${{ github.repository_owner }}/$(basename ${{ github.repository }}):latest
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.TAG }}
+            ghcr.io/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -15,21 +15,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version tag
         id: vars
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./agate
           push: true

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           context: ./agate
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.TAG }}
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This adds an action to build an image and push it to the GitHub container registry when a tag is pushed. 

~I'm not sure there is a way to test this other than trying to make some tags once it is merged? @warrickball do you know?~

[I created a tag on my branch](https://github.com/tomneep/agate/pkgs/container/agate) and the image seems to have been created and pushed! I can run it locally with

`podman run -it --rm --entrypoint /bin/bash ghcr.io/tomneep/agate:latest`

This can be merged before #25, but ideally we merge #25 too before pushing a tag on the CLIMB-TRE version of the repo!