### PR TITLE
Make sure ghcr path is lower case

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -38,7 +38,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.TAG }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository.toLowerCase() }}:${{ steps.vars.outputs.TAG }}
+            ghcr.io/${{ github.repository.toLowerCase() }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Fixes error found in [CI](https://github.com/CLIMB-TRE/agate/actions/runs/23239239943/job/67551054615). For ghcr the repository must be lower case. It doesn't work for `CLIMB-TRE` (but did for `tomneep`).